### PR TITLE
Edge case with GWX on Windows 8.1

### DIFF
--- a/win-10-off.bat
+++ b/win-10-off.bat
@@ -86,15 +86,15 @@ exit
 	start "hiding" /b /w cscript.exe "%~dp0HideUpdates.vbs" 971033 2952664 2976978 29777598 2990214 3012973 3014460 3015249 3021917 3022345 3035583 3044374 3050265 3050267 3068708 3075249 3075851 3075853 3080149
 	echo Done.
 	ping 127.0.0.1 -n 2 > null
-	goto checkDownlaodFolder
+	goto checkDownloadFolder
 
-:checkDownlaodFolder
+:checkDownloadFolder
 	echo Checking if Windows 10 download has been started...
 	echo.
 	IF NOT EXIST %SystemDrive%\$Windows.~BT\ (
 		echo The Windows 10 download has not been initiated - you are OK!
 	) else (
-		echo Unofortunately Windows 10 download has already started :(
+		echo Unfortunately Windows 10 download has already started :(
 		echo But the removal of these updates has stopped it of further download!
 		echo you can check the directory yourself at %SystemDrive%\$Windows.~BT\
 		echo NOTE: the directory is hidden, so turn on "Show hidden files"

--- a/win-10-off.bat
+++ b/win-10-off.bat
@@ -101,6 +101,16 @@ exit
 		echo.
 		pause
 	)
+	goto hideGWX
+
+:hideGWX
+	echo "Preventing GWX from launching in future..."
+	reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\GWX" /v "DisableGWX" /t REG_DWORD /d 1 /f
+	reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DisableOSUpgrade" /t REG_DWORD /d 1 /f
+	reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\OSUpgrade" /v "AllowOSUpgrade" /t REG_DWORD /d 0 /f
+	reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\OSUpgrade" /v "KickoffDownload" /t REG_DWORD /d 0 /f
+	reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\OSUpgrade" /v "OSUpgradeInteractive" /t REG_DWORD /d 0 /f
+	reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\OSUpgrade" /v "ReservationsAllowed" /t REG_DWORD /d 0 /f
 	goto quit
 
 :quit


### PR DESCRIPTION
Greta script. Just one minor fix in an edge case.

If the OS is Windows 8.1 AND the GWX installer has already run AND the GWX installer is then uninstalled THEN GWX itself doesn't actually get disabled.

The attached pull request also installs the registry settings to subsequently block GWX from running in this case.
